### PR TITLE
Handle access_denied from Hello, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ It is based off the <a href="https://github.com/hellocoop/greenfielddemo">Single
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/irrelevelephant/next-with-hello&project-name=next-with-hello&repository-name=next-with-hello)
 
 Use the [Hellō developer console](https://console.hello.dev/) to create your own Hellō application. The client ID is configured via environment variables.
+
+## Development
+
+1. Clone the repo/deploy your own. (You'll have to fork the repo if you want to submit PRs)
+2. `yarn install`
+  - You might have to update node with `nvm install --lts` and `nvm use --lts`
+3. `yarn dev`

--- a/pages/api/callback.ts
+++ b/pages/api/callback.ts
@@ -16,7 +16,16 @@ type Claims = {
 const defaultReturnTo = '/'
 
 const callbackRoute = async (req: NextApiRequest, res: NextApiResponse) => {
-    const { query: { idToken: idTokenParam } } = req
+    const { query: { idToken: idTokenParam, error: errorParam } } = req
+
+    if (errorParam) {
+        if (errorParam === "access_denied") {
+            res.status(403).json({ message: 'Access denied received from Hellō' })
+            return
+        }
+        res.status(400).json({ message: errorParam })
+        return
+    }
 
     const idToken = Array.isArray(idTokenParam) ? idTokenParam[0] : idTokenParam
 

--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -9,8 +9,12 @@ export default function Callback() {
             const params = new URLSearchParams(window.location.hash.substring(1))
 
             const idToken = params.get('id_token')
+            const error = params.get('error')
+
             if (idToken) {
                 push('/api/callback?' + new URLSearchParams({ idToken }))
+            } else if (error) {
+                push('/api/callback?' + new URLSearchParams({ error }))
             }
         }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,7 +30,7 @@ export default function Home() {
             <h2>Steps to test the functionality:</h2>
 
             <ol>
-                <li>Click <b>Login</b></li>
+                <li>Click <b>Login</b> (on the top right)</li>
                 <li>Click <b>Continue with Hellō</b></li>
                 <li>
                     Click home and click profile again, notice how your session is being


### PR DESCRIPTION
When a user decides to not proceed with hellō, the user is redirected back to the configured `callback` URL with the following:

```
- http://localhost:3000/callback#error=access_denied&error_description=&error_uri=
- https://next-with-hello-leewc.vercel.app/#error=access_denied&error_description=&error_uri=
```

This PR checks if the hash contains and error, redirects to the backend and returns a `403` if it is denied. 
An alternative behavior would be to redirect back to `/` and have a message bubble saying Hello OAuth flow cancelled.

Docs: 
- https://www.hello.dev/documentation/errors.html#request-errors

Testing:
- Click Login
- Continue with Hello
- Select an identity provider and then click 'cancel' on the OAuth dialog.
- Redirection happens.

Code can be played around here: http://next-with-hello-leewc.vercel.app/ (or copy paste the URL above to simulate the behavior).

I cloned the repo using Vercel (which unfortunately makes the repo a standalone/not a Github fork, so I had to test and then cherry-pick the commit over).

